### PR TITLE
Development - Fix: PIA Port Forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN addgroup -S openvpn \
     libcap \
     sudo \
     subversion \
+    jq \
     && setcap cap_net_admin+ep "$(which openvpn)" \
     && apk del libcap --purge \
     && echo "openvpn ALL=(ALL)  NOPASSWD: /sbin/ip" >> /etc/sudoers \

--- a/rootfs/usr/sbin/pia_port.sh
+++ b/rootfs/usr/sbin/pia_port.sh
@@ -22,7 +22,7 @@ get_auth_token () {
 
 get_auth_token
 
-yes ''>/dev/null | sed 3q
+yes '' | sed 3q
 
 get_sig () {
   pf_getsig=$(curl --insecure --get --silent --show-error \

--- a/rootfs/usr/sbin/pia_port.sh
+++ b/rootfs/usr/sbin/pia_port.sh
@@ -6,8 +6,8 @@
 curl_max_time=15
 curl_retry=5
 curl_retry_delay=15
-user=$(sed -n 1p /config/openvpn-credentials.txt)
-pass=$(sed -n 2p /config/openvpn-credentials.txt)
+user=$(sed -n 1p /config/openvpn/openvpn-credentials.txt)
+pass=$(sed -n 2p /config/openvpn/openvpn-credentials.txt)
 pf_host=$(ip route | grep tun | grep -v src | head -1 | awk '{ print $3 }')
 ###### Nextgen PIA port forwarding      ##################
    

--- a/rootfs/usr/sbin/pia_port.sh
+++ b/rootfs/usr/sbin/pia_port.sh
@@ -22,7 +22,7 @@ get_auth_token () {
 
 get_auth_token
 
-yes '' | sed 3q
+yes ''>/dev/null | sed 3q
 
 get_sig () {
   pf_getsig=$(curl --insecure --get --silent --show-error \


### PR DESCRIPTION
Fixed the openvpn-credentials.txt location and added jq to the list of apks to be installed on docker creation. There are still some errors:
```
yes: Broken pipe
curl: (3) URL using bad/illegal format or missing URL
port is 50213
curl: (3) URL using bad/illegal format or missing URL
the port has been bound to 50213  Thu Nov 19 06:40:17 UTC 2020
Got new port 50213 from PIA
```
but as you can see, the port forwarding does indeed work now.