### PR TITLE
Fix healthcheck, add autoheal label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-url="https://github.com/guillaumedsde/alpine-qbittorrent-openvpn" \
     org.label-schema.vendor="guillaumedsde" \
     org.label-schema.version=$VERSION \
-    org.label-schema.schema-version="1.0"
+    org.label-schema.schema-version="1.0" \
+    autoheal=true
 
 COPY rootfs /
 

--- a/rootfs/usr/sbin/healthcheck.sh
+++ b/rootfs/usr/sbin/healthcheck.sh
@@ -23,15 +23,15 @@ fi
 echo "Network is up"
 
 #Service check
-#Expected output is 2 for both checks, 1 for process and 1 for grep
-OPENVPN=$(ps -ef | grep 'openvpn --writepid' | wc | awk '{print $1}')
-QBITTORRENT=$(ps -ef | grep 'qbittorrent-nox' | wc | awk '{print $1}')
+#Expected output is 1 for both checks
+OPENVPN=$(pgrep openvpn | wc -l)
+QBITTORRENT=$(pgrep qbittorrent-nox | wc -l)
 
-if [ "${OPENVPN}" -ne 2 ]; then
+if [[ ${OPENVPN} -ne 1 ]]; then
     echo "Openvpn process not running"
     exit 1
 fi
-if [ "${QBITTORRENT}" -ne 2 ]; then
+if [[ ${QBITTORRENT} -ne 1 ]]; then
     echo "qbittorrent-nox process not running"
     exit 1
 fi


### PR DESCRIPTION
Fixes #43 

The autoheal label makes it possible to restart the container on failing healthchecks, see https://github.com/willfarrell/docker-autoheal