### PR TITLE
nordvpn scripts require bash interpreter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN addgroup -S openvpn \
     -G openvpn \
     openvpn \
     && apk add --no-cache \
+    bash \
     openvpn \
     curl \
     iptables \


### PR DESCRIPTION
This PR fixes #35 as the NORDVPN scripts both require `bash`

ref: https://github.com/haugene/docker-transmission-openvpn/blob/master/openvpn/nordvpn/configure-openvpn.sh

Signed-off-by: kevin crawley <kevin@nashgo.org>