### PR TITLE
Add unrar to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN addgroup -S openvpn \
     sudo \
     subversion \
     jq \
+    unrar \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
     s6-overlay \
     && setcap cap_net_admin+ep "$(which openvpn)" \


### PR DESCRIPTION
Lots of torrents come in rar'ed. Adding `unrar` to the image will allow users to use qBittorrent's `Run external program`  to unrar any rar files. 

This is something I've been adding to the image myself for a while and thought everyone else might want it. 