### PR TITLE
update openvpn configs pull location

### DIFF
--- a/rootfs/etc/cont-init.d/02-setup-openvpn
+++ b/rootfs/etc/cont-init.d/02-setup-openvpn
@@ -43,7 +43,7 @@ else
     (
         # shellcheck disable=SC2164
         cd "/etc/openvpn"
-        svn export "https://github.com/haugene/docker-transmission-openvpn.git/trunk/openvpn/${lowercase_openvpn_provider}" --force
+        svn export "https://github.com/haugene/vpn-configs-contrib/trunk/openvpn/${lowercase_openvpn_provider}" --force
     )
 
     if [ -x "/etc/openvpn/${lowercase_openvpn_provider}/configure-openvpn.sh" ]; then


### PR DESCRIPTION
Recently haugene decoupled the vpn configs from the transmission project. This updates the script to pull the configs from the vpn-configs-contrib project.