### PR TITLE
Fix port forwarding script

### DIFF
--- a/rootfs/usr/sbin/set_qbittorrent_port_forwarding.sh
+++ b/rootfs/usr/sbin/set_qbittorrent_port_forwarding.sh
@@ -4,18 +4,32 @@ port="$1"
 
 QBT_CONFIG_FILE="${CONFIG_DIR}/qBittorrent/config/qBittorrent.conf"
 
-if [ -f "$QBT_CONFIG_FILE" ]; then
-    # if Connection address line exists
-    if grep -q 'Connection\\PortRangeMin' "$QBT_CONFIG_FILE"; then
-        # Set connection interface address to the VPN address
-        sed -i -E 's/^.*\b(Connection.*PortRangeMin)\b.*$/Connection\\PortRangeMin='"$port"'/' "$QBT_CONFIG_FILE"
-    else
-        # add the line for configuring interface address to the qBittorrent config file
-        printf 'Connection\\PortRangeMin=%s' "$port" >>"$QBT_CONFIG_FILE"
-    fi
+if pgrep "qbittorrent-nox" >/dev/null 2>$1; then
+        # Check if we need to use HTTPS
+        echo "Setting port via WebUI"
+        if grep -q 'WebUI\\HTTPS\\Enabled=true' "$QBT_CONFIG_FILE"; then
+                echo "Using HTTPS"
+                address=https://127.0.0.1:8080/api/v2/app/setPreferences
+        else
+                address=http://127.0.0.1:8080/api/v2/app/setPreferences
+        fi
+        curl -k --data 'json={"listen_port": '$port'}' $address
 else
-    # Ensure config directory is created
-    mkdir -p "$(dirname "$QBT_CONFIG_FILE")"
-    # Create the configuration file from a template and environment variables
-    printf '[Preferences]\nConnection\\PortRangeMin=%s\n' "$port" >"$QBT_CONFIG_FILE"
+        echo "Setting port in config file"
+        if [ -f "$QBT_CONFIG_FILE" ]; then
+                # if session port line exists
+                if grep -q 'Session\\Port' "$QBT_CONFIG_FILE"; then
+                        # Set connection interface address to the VPN address
+                        sed -i -E 's/^.*\b(Session.*Port)\b.*$/Session\\Port='"$port"'/' "$QBT_CONFIG_FILE"
+                else
+                        # add the line for configuring interface address to the qBittorrent config file
+                        printf 'Session\\Port=%s' "$port" >>"$QBT_CONFIG_FILE"
+                fi
+        else
+                # Ensure config directory is created
+                mkdir -p "$(dirname "$QBT_CONFIG_FILE")"
+                # Create the configuration file from a template and environment variables
+                printf '[BitTorrent]\nSession\\Port=%s\n' "$port" >"$QBT_CONFIG_FILE"
+        fi
 fi
+


### PR DESCRIPTION
Script had two problems:
1.) Setting the config file does not affect the currently running instance. Using the WebUI API applies the change immediately. This does require the option "Bypass authentication for clients on localhost" to be enabled (WebUI\LocalHostAuth=false) ahead of time.
2.) The PortRangeMin setting is obsoleted. Bittorrent\Session\Port should be used now (https://github.com/qbittorrent/qBittorrent/issues/8324)