### PR TITLE
Add mssfix override enviroment variable

### DIFF
--- a/rootfs/etc/cont-init.d/02-setup-openvpn
+++ b/rootfs/etc/cont-init.d/02-setup-openvpn
@@ -75,7 +75,7 @@ else
     cp -p "${DOWNLOADED_OPENVPN_CONFIG_FILE}" "${OPENVPN_CONFIG_FILE}"
 fi
 
-if [ -z "${MSSFIX_OVERRIDE}" ]; then
+if [ -n "${MSSFIX_OVERRIDE}" ]; then
 	# If mssfix line exists
 	if grep -q 'mssfix' "${OPENVPN_CONFIG_FILE}"; then
 		# Override existing value

--- a/rootfs/etc/cont-init.d/02-setup-openvpn
+++ b/rootfs/etc/cont-init.d/02-setup-openvpn
@@ -75,4 +75,15 @@ else
     cp -p "${DOWNLOADED_OPENVPN_CONFIG_FILE}" "${OPENVPN_CONFIG_FILE}"
 fi
 
+if [ -z "${MSSFIX_OVERRIDE}" ]; then
+	# If mssfix line exists
+	if grep -q 'mssfix' "${OPENVPN_CONFIG_FILE}"; then
+		# Override existing value
+		sed -i -e 's/mssfix [0-9]*/mssfix ${MSSFIX_OVERRIDE}/' "${OPENVPN_CONFIG_FILE}"
+	else
+		# Add line for mssfix value
+		printf 'mssfix' "${MSSFIX_OVERRIDE}" >>"${OPENVPN_CONFIG_FILE}"
+	fi
+fi
+
 chown openvpn:openvpn "${OPENVPN_CONFIG_FILE}"


### PR DESCRIPTION
Running in a docker container in certain enviroments can lead to MTU size errors such as described [here ](https://www.adamintech.com/how-to-fix-aead-decrypt-error-bad-packet-id-on-openvpn/).

This can be fixed with a custom openvpn configuration file with the mssfix option. If you want to use the automatic configuration options there was no solution.

This checks for an environment variable (MSSFIX_OVERRIDE) to add or override mssfix line in the configuration file to overcome this issue.